### PR TITLE
docs: Update DPoP references to bound_key in OIDC documentation

### DIFF
--- a/pages/docs/oidc/request.mdx
+++ b/pages/docs/oidc/request.mdx
@@ -32,7 +32,7 @@ The **request URL** is `https://wallet.hello.coop/authorize` and a query with th
 |`prompt`<br/>*optional*|A space delimited list. Accepted values include:|
 |                   | - `login` will require the user to re-authenticate at their login provider|
 |                   | - `consent` will require the user to review, and potentially change, released claims|
-|`dpop_jkt` <ExperimentalTooltip />|JWK Thumbprint of the DPoP public key using SHA-256. Required when using `dpop` scope.|
+|`dpop_jkt` <ExperimentalTooltip />|JWK Thumbprint of the DPoP public key using SHA-256. Required when using `bound_key` scope.|
 
 ### Hellō Parameters
 

--- a/pages/docs/oidc/token.mdx
+++ b/pages/docs/oidc/token.mdx
@@ -27,7 +27,7 @@ iUwBbgx0XoFeIn4jQtMNydaksmbPqZFtAFNUKUM85KFnKAx_OMrhqEU0b3lc4kbR1Na_orr4Ucm1e-_p
 
 ### Decoded ID Token
 
-Note: The following example includes the `cnf` claim that appears when the `dpop` scope is requested:
+Note: The following example includes the `cnf` claim that appears when the `bound_key` scope is requested:
 
 ```json
 {
@@ -103,4 +103,4 @@ Note: The following example includes the `cnf` claim that appears when the `dpop
 |`iat`|The time the ID Token was issued in [Epoch time](https://en.wikipedia.org/wiki/Unix_time)|
 |`exp`|The time the ID Token expires.<br/>Hellō sets the expiry to be 5 minutes (300 seconds) after `iat`|
 |`tenant`|The Hellō identifier for the organization. Similar to `sub`, use this to identify the organization. Set to `personal` for personal accounts.|
-|`cnf` <ExperimentalTooltip />|Confirmation claim containing the public key bound to the ID token when using `dpop` scope.|
+|`cnf` <ExperimentalTooltip />|Confirmation claim containing the public key bound to the ID token when using `bound_key` scope.|

--- a/pages/docs/scopes.mdx
+++ b/pages/docs/scopes.mdx
@@ -37,7 +37,7 @@ Following are the scopes currently supported by Hellō. At the top are the stand
 |`picture`|A URL to a profile picture. [See FAQ 13](/faqs/#13-what-can-i-do-with-the-picture-url-i-receive) for details|
 |`profile`|equivalent to `name`, `email`, and `picture`|
 |**Experimental**|**The following scopes are currently experimental**|
-|`dpop` <ExperimentalTooltip/>|Enables key binding for ID tokens using RFC 9449 DPoP.|
+|`bound_key` <ExperimentalTooltip/>|Enables key binding for ID tokens using RFC 9449 DPoP.|
 
 *NOTE: We previously returned `phone` and `phone_verified` claims and now return `phone_number` and `phone_number_verified` claims per [OIDC Standard Claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims)*
 


### PR DESCRIPTION
- Replaced instances of `dpop` with `bound_key` in scopes, request, and token documentation to reflect the new terminology.
- Clarified the implications of using `bound_key` for ID tokens and related claims.
- Enhanced user understanding of the changes in scope usage and its impact on authentication requests.